### PR TITLE
add data shortcut for attribute expression

### DIFF
--- a/lib/xpath/dsl.rb
+++ b/lib/xpath/dsl.rb
@@ -37,6 +37,10 @@ module XPath
         Expression.new(:attribute, current, expression)
       end
 
+      def data(expression)
+        Expression.new(:attribute, current, :"data-#{expression}")
+      end
+
       def contains(expression)
         Expression.new(:contains, current, expression)
       end

--- a/spec/fixtures/simple.html
+++ b/spec/fixtures/simple.html
@@ -22,6 +22,9 @@
       <p id="wooDiv">Blah</p>
     </div>
 
+    <div data-foo="buz" title="buzDiv"></div>
+    <div data-foo="fuz" title="fuzDiv"></div>
+
     <div id="baz" title="bazDiv"></div>
 
     <div id="preference">

--- a/spec/xpath_spec.rb
+++ b/spec/xpath_spec.rb
@@ -303,6 +303,14 @@ describe XPath do
     end
   end
 
+  describe '#data' do
+    it "should be a data attribute" do
+      @results = xpath { |x| x.descendant(:div).where(x.data(:foo)) }
+      @results[0][:title].should == "buzDiv"
+      @results[1][:title].should == "fuzDiv"
+    end
+  end
+
   describe '#css' do
     it "should find nodes by the given CSS selector" do
       @results = xpath { |x| x.css('#preference p') }


### PR DESCRIPTION
A new feature being introduced in HTML 5 is the addition of custom data attributes.

As example :

``` html
<div class="user" data-name="Akarzim" data-city="Lille">
  <b>Akarzim says:</b> <span>Hello, how are you?</span>
</div>
```

With this new expression, as a shortcut of `XPath.attr(:"data-name")` now we can use `XPath.data(:name)`
