### PR TITLE
add support for ends-with function

### DIFF
--- a/lib/xpath/dsl.rb
+++ b/lib/xpath/dsl.rb
@@ -45,6 +45,10 @@ module XPath
         Expression.new(:starts_with, current, expression)
       end
 
+      def ends_with(expression)
+        Expression.new(:ends_with, current, expression)
+      end
+
       def text
         Expression.new(:text, current)
       end

--- a/lib/xpath/renderer.rb
+++ b/lib/xpath/renderer.rb
@@ -131,6 +131,11 @@ module XPath
       "starts-with(#{current}, #{value})"
     end
 
+    def ends_with(current, value)
+      start_at = "#{string_length_function(current)} - #{string_length_function(string_function(value))} + 1"
+      equality(string_function(value), substring_function(current, start_at))
+    end
+
     def and(one, two)
       "(#{one} and #{two})"
     end

--- a/spec/fixtures/simple.html
+++ b/spec/fixtures/simple.html
@@ -22,6 +22,8 @@
       <p id="wooDiv">Blah</p>
     </div>
 
+    <div id="barfoo" title="fooBarfoo"></div>
+
     <div id="baz" title="bazDiv"></div>
 
     <div id="preference">

--- a/spec/xpath_spec.rb
+++ b/spec/xpath_spec.rb
@@ -181,6 +181,26 @@ describe XPath do
     end
   end
 
+  describe '#ends_with' do
+    it "should find nodes that finish with the given string" do
+      @results = xpath do |x|
+        x.descendant(:*).where(x.attr(:id).ends_with('foo'))
+      end
+      @results.size.should == 2
+      @results[0][:id].should == "foo"
+      @results[1][:id].should == "barfoo"
+    end
+
+    it "should find nodes that contain the given expression" do
+      @results = xpath do |x|
+        expression = x.anywhere(:div).where(x.attr(:title) == 'fooDiv').attr(:id)
+        x.descendant(:div).where(x.attr(:title).ends_with(expression))
+      end
+      @results.size.should == 1
+      @results[0][:id].should == "barfoo"
+    end
+  end
+
   describe '#text' do
     it "should select a node's text" do
       @results = xpath { |x| x.descendant(:p).where(x.text == 'Bax') }


### PR DESCRIPTION
reimplements XPath 2.0 ends-with function using XPath 1.0 string, substring and string-length functions.

see http://www.w3.org/TR/xpath/#section-String-Functions
