### PR TITLE
Improve HTML#link to handle &nbsp; characters in link text

### DIFF
--- a/lib/xpath/dsl.rb
+++ b/lib/xpath/dsl.rb
@@ -117,6 +117,10 @@ module XPath
         Expression.new(:normalized_space, current)
       end
       alias_method :n, :normalize
+
+      def replace_spaces
+        Expression.new(:replace_spaces, current)
+      end
     end
   end
 end

--- a/lib/xpath/html.rb
+++ b/lib/xpath/html.rb
@@ -11,7 +11,7 @@ module XPath
     def link(locator)
       locator = locator.to_s
       link = descendant(:a)[attr(:href)]
-      link[attr(:id).equals(locator) | string.n.is(locator) | attr(:title).is(locator) | descendant(:img)[attr(:alt).is(locator)]]
+      link[attr(:id).equals(locator) | string.replace_spaces.is(locator) | attr(:title).is(locator) | descendant(:img)[attr(:alt).is(locator)]]
     end
 
     # Match a `submit`, `image`, or `button` element.

--- a/lib/xpath/renderer.rb
+++ b/lib/xpath/renderer.rb
@@ -98,6 +98,13 @@ module XPath
       "normalize-space(#{current})"
     end
 
+    # normalize-space only detects these characters: x20 x09 x0D x0A. This adds
+    # other whitespace characters to the list that will be normalised into x20
+    # (space). 0xC2 0xA0 is a utf-8 non-breaking space.
+    def replace_spaces(current)
+      "translate(normalize-space(#{current}),'\xC2\xA0',' ')"
+    end
+
     def literal(node)
       node
     end

--- a/lib/xpath/renderer.rb
+++ b/lib/xpath/renderer.rb
@@ -100,9 +100,10 @@ module XPath
 
     # normalize-space only detects these characters: x20 x09 x0D x0A. This adds
     # other whitespace characters to the list that will be normalised into x20
-    # (space). 0xC2 0xA0 is a utf-8 non-breaking space.
+    # (space). 160 is a unicode non-breaking space.
     def replace_spaces(current)
-      "translate(normalize-space(#{current}),'\xC2\xA0',' ')"
+      nbsp = [160].pack("U")
+      "translate(normalize-space(#{current}),'#{nbsp}',' ')"
     end
 
     def literal(node)

--- a/spec/fixtures/form.html
+++ b/spec/fixtures/form.html
@@ -15,6 +15,7 @@
 
       whitespaced
     link</a>
+  <a href="#nbsp-spacey" data="link-nbsp">My&nbsp;nbsp&nbsp;link</a>
   <a href="#has-children" data="link-children">
     An <em>emphatic</em> link with some children
   </a>

--- a/spec/html_spec.rb
+++ b/spec/html_spec.rb
@@ -21,6 +21,7 @@ describe XPath::HTML do
     it("finds links by id")                                { get('some-id').should == 'link-id' }
     it("finds links by content")                           { get('An awesome link').should == 'link-text' }
     it("finds links by content regardless of whitespace")  { get('My whitespaced link').should == 'link-whitespace' }
+    it("finds links by content regardless of nbsp")        { get('My nbsp link').should == 'link-nbsp' }
     it("finds links with child tags by content")           { get('An emphatic link').should == 'link-children' }
     it("finds links by the content of their child tags")   { get('emphatic').should == 'link-children' }
     it("finds links by approximate content")               { get('awesome').should == 'link-text' }


### PR DESCRIPTION
If a HTML document has the following link:

```
<a href="http://example.com">foo&nbsp;bar</a>
```

This change means the following call will generate an xpath query that will match it:

```
XPath::HTML.link("foo bar")
```
