### PR TITLE
Infrastructure changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@
 .yardoc
 doc
 Gemfile.lock
-bundler_stubis
 gem-private_key.pem

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .rvmrc
+.ruby-version
+.ruby-gemset
 .bundle
 .yardoc
 doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 rvm:
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
   - 2.0.0
-  - ruby-head
-  - ree
-  - rbx-18mode
+  - 2.1.1
   - jruby
+  - rbx

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 XPath is a Ruby DSL around a subset of XPath 1.0. Its primary purpose is to
 facilitate writing complex XPath queries from Ruby code.
 
+[![Gem Version](https://badge.fury.io/rb/xpath.png)](http://badge.fury.io/rb/xpath)
 [![Build Status](https://secure.travis-ci.org/jnicklas/xpath.png?branch=master)](http://travis-ci.org/jnicklas/xpath)
 
 ## Generating expressions

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'rspec/core/rake_task'
 require 'yard'
 
@@ -9,7 +8,7 @@ RSpec::Core::RakeTask.new(:spec) do |t|
 end
 
 YARD::Rake::YardocTask.new do |t|
-  t.files   = ['lib/**/*.rb', 'README.rdoc']
+  t.files   = ['lib/**/*.rb', 'README.md']
   #t.options = ['--any', '--extra', '--opts'] # optional
 end
 

--- a/xpath.gemspec
+++ b/xpath.gemspec
@@ -1,13 +1,11 @@
-# -*- encoding: utf-8 -*-
 lib = File.expand_path('lib', File.dirname(__FILE__))
 $:.unshift lib unless $:.include?(lib)
-
 require 'xpath/version'
 
 Gem::Specification.new do |s|
   s.name = "xpath"
-  s.rubyforge_project = "xpath"
   s.version = XPath::VERSION
+  s.required_ruby_version = ">= 1.9.3"
 
   s.authors = ["Jonas Nicklas"]
   s.email = ["jonas.nicklas@gmail.com"]
@@ -15,17 +13,13 @@ Gem::Specification.new do |s|
   s.license = "MIT"
 
   s.files = Dir.glob("{lib,spec}/**/*") + %w(README.md)
-  s.extra_rdoc_files = ["README.md"]
 
-  s.homepage = "http://github.com/jnicklas/xpath"
-  s.rdoc_options = ["--main", "README.md"]
-  s.require_paths = ["lib"]
-  s.rubygems_version = "1.3.6"
+  s.homepage = "https://github.com/jnicklas/xpath"
   s.summary = "Generate XPath expressions from Ruby"
 
   s.add_dependency("nokogiri", ["~> 1.3"])
 
-  s.add_development_dependency("rspec", ["~> 2.0"])
+  s.add_development_dependency("rspec", [">= 2.0"])
   s.add_development_dependency("yard", [">= 0.5.8"])
   s.add_development_dependency("rake")
 


### PR DESCRIPTION
- Remove references to RubyForge as it will die soon
- Require Ruby >= 1.9.3 and build on newer rubies
- Remove bundler_stubis from gitignore as Google knows nothing about it
- Remove references to RDoc as project uses YARD
- Remove rubygems_version as it shouldn't be specified
