### PR TITLE
Revises click_on to work for AngularJS a[ng-click] elements without href attributes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .rvmrc
 .bundle
 .yardoc
+.idea
 doc
 Gemfile.lock
 bundler_stubis

--- a/lib/xpath/html.rb
+++ b/lib/xpath/html.rb
@@ -10,7 +10,7 @@ module XPath
     #
     def link(locator)
       locator = locator.to_s
-      link = descendant(:a)[attr(:href)]
+      link = descendant(:a)
       link[attr(:id).equals(locator) | string.n.is(locator) | attr(:title).is(locator) | descendant(:img)[attr(:alt).is(locator)]]
     end
 

--- a/spec/fixtures/form.html
+++ b/spec/fixtures/form.html
@@ -10,7 +10,7 @@
   <a href="#bar" data="link-img-fuzzy"><img src="foo.png" alt="An image that is beautiful"/></a>
   <a href="#foo" data="link-img-exact"><img src="foo.ong" alt="An image"/></a>
   <a href="http://www.example.com" data="link-href">Href-ed link</a>
-  <a>Wrong Link</a>
+  <a ng-click="foo()" data="link-ng">No Href Link</a>
   <a href="#spacey" data="link-whitespace">    My
 
       whitespaced

--- a/spec/html_spec.rb
+++ b/spec/html_spec.rb
@@ -28,7 +28,7 @@ describe XPath::HTML do
     it("finds links by approximate title")                 { get('title').should == 'link-title' }
     it("finds links by image's alt attribute")             { get('Alt link').should == 'link-img' }
     it("finds links by image's approximate alt attribute") { get('Alt').should == 'link-img' }
-    it("does not find links without href attriutes")       { get('Wrong Link').should be_nil }
+    it("finds links without href attributes")              { get('No Href Link').should == 'link-ng' }
     it("casts to string")                                  { get(:'some-id').should == 'link-id' }
 
     context "with exact match", :type => :exact do


### PR DESCRIPTION
Because I use Capybara to tests AngularJS apps, I often run across links that look something like this:

    <a ng-click="doCoolStuff()">Get Some Bacon</a>

It took me awhile to chase down why `click_on 'Get Some Bacon'` didn't work.  The xpath gem explicitly does not find link elements without href attributes.  I don't think that's viable in today's JavaScript-intensive world.

So here's a patch to enable click_on to find those links.  In my opinion, even if they don't have an href attribute, they should still be findable for clicking.