### PR TITLE
allow nil locators to devolve to just finding html elements

### DIFF
--- a/lib/xpath/html.rb
+++ b/lib/xpath/html.rb
@@ -9,9 +9,12 @@ module XPath
     #   Text, id, title, or image alt attribute of the link
     #
     def link(locator)
-      locator = locator.to_s
       link = descendant(:a)[attr(:href)]
-      link[attr(:id).equals(locator) | string.n.is(locator) | attr(:title).is(locator) | descendant(:img)[attr(:alt).is(locator)]]
+      unless locator.nil?
+        locator = locator.to_s
+        link = link[attr(:id).equals(locator) | string.n.is(locator) | attr(:title).is(locator) | descendant(:img)[attr(:alt).is(locator)]]
+      end
+      link
     end
 
     # Match a `submit`, `image`, or `button` element.
@@ -20,10 +23,18 @@ module XPath
     #   Value, title, id, or image alt attribute of the button
     #
     def button(locator)
-      locator = locator.to_s
-      button = descendant(:input)[attr(:type).one_of('submit', 'reset', 'image', 'button')][attr(:id).equals(locator) | attr(:value).is(locator) | attr(:title).is(locator)]
-      button += descendant(:button)[attr(:id).equals(locator) | attr(:value).is(locator) | string.n.is(locator) | attr(:title).is(locator)]
-      button += descendant(:input)[attr(:type).equals('image')][attr(:alt).is(locator)]
+      input_button = descendant(:input)[attr(:type).one_of('submit', 'reset', 'image', 'button')]
+      button = descendant(:button)
+      image_button = descendant(:input)[attr(:type).equals('image')]
+
+      unless locator.nil?
+        locator = locator.to_s
+        input_button = input_button[attr(:id).equals(locator) | attr(:value).is(locator) | attr(:title).is(locator)]
+        button = button[attr(:id).equals(locator) | attr(:value).is(locator) | string.n.is(locator) | attr(:title).is(locator)]
+        image_button = image_button[attr(:alt).is(locator)]
+      end
+
+      input_button + button + image_button
     end
 
 
@@ -43,8 +54,12 @@ module XPath
     #   Legend or id of the fieldset
     #
     def fieldset(locator)
-      locator = locator.to_s
-      descendant(:fieldset)[attr(:id).equals(locator) | child(:legend)[string.n.is(locator)]]
+      fieldset = descendant(:fieldset)
+      unless locator.nil?
+        locator = locator.to_s
+        fieldset = fieldset[attr(:id).equals(locator) | child(:legend)[string.n.is(locator)]]
+      end
+      fieldset
     end
 
 
@@ -55,9 +70,8 @@ module XPath
     #   Label, id, or name of field to match
     #
     def field(locator)
-      locator = locator.to_s
       xpath = descendant(:input, :textarea, :select)[~attr(:type).one_of('submit', 'image', 'hidden')]
-      xpath = locate_field(xpath, locator)
+      xpath = locate_field(xpath, locator.to_s) unless locator.nil?
       xpath
     end
 
@@ -70,9 +84,8 @@ module XPath
     #   Label, id, or name of field to match
     #
     def fillable_field(locator)
-      locator = locator.to_s
       xpath = descendant(:input, :textarea)[~attr(:type).one_of('submit', 'image', 'radio', 'checkbox', 'hidden', 'file')]
-      xpath = locate_field(xpath, locator)
+      xpath = locate_field(xpath, locator.to_s) unless locator.nil?
       xpath
     end
 
@@ -83,8 +96,9 @@ module XPath
     #   Label, id, or name of the field to match
     #
     def select(locator)
-      locator = locator.to_s
-      locate_field(descendant(:select), locator)
+      xpath = descendant(:select)
+      xpath = locate_field(xpath, locator.to_s) unless locator.nil?
+      xpath
     end
 
 
@@ -94,8 +108,9 @@ module XPath
     #   Label, id, or name of the checkbox to match
     #
     def checkbox(locator)
-      locator = locator.to_s
-      locate_field(descendant(:input)[attr(:type).equals('checkbox')], locator)
+      xpath = descendant(:input)[attr(:type).equals('checkbox')]
+      xpath = locate_field(xpath, locator.to_s) unless locator.nil?
+      xpath
     end
 
 
@@ -105,8 +120,9 @@ module XPath
     #   Label, id, or name of the radio button to match
     #
     def radio_button(locator)
-      locator = locator.to_s
-      locate_field(descendant(:input)[attr(:type).equals('radio')], locator)
+      xpath = descendant(:input)[attr(:type).equals('radio')]
+      xpath = locate_field(xpath, locator.to_s) unless locator.nil?
+      xpath
     end
 
 
@@ -116,8 +132,9 @@ module XPath
     #   Label, id, or name of the file field to match
     #
     def file_field(locator)
-      locator = locator.to_s
-      locate_field(descendant(:input)[attr(:type).equals('file')], locator)
+      xpath = descendant(:input)[attr(:type).equals('file')]
+      xpath = locate_field(xpath, locator.to_s) unless locator.nil?
+      xpath
     end
 
 
@@ -127,8 +144,9 @@ module XPath
     #   Label for the option group
     #
     def optgroup(locator)
-      locator = locator.to_s
-      descendant(:optgroup)[attr(:label).is(locator)]
+      xpath = descendant(:optgroup)
+      xpath = xpath[attr(:label).is(locator.to_s)] unless locator.nil?
+      xpath
     end
 
 
@@ -138,8 +156,9 @@ module XPath
     #   Visible text of the option
     #
     def option(locator)
-      locator = locator.to_s
-      descendant(:option)[string.n.is(locator)]
+      xpath = descendant(:option)
+      xpath = xpath[string.n.is(locator.to_s)] unless locator.nil?
+      xpath
     end
 
 
@@ -151,8 +170,9 @@ module XPath
     #   Content of each cell in each row to match
     #
     def table(locator)
-      locator = locator.to_s
-      descendant(:table)[attr(:id).equals(locator) | descendant(:caption).is(locator)]
+      xpath = descendant(:table)
+      xpath = xpath[attr(:id).equals(locator.to_s) | descendant(:caption).is(locator.to_s)] unless locator.nil?
+      xpath
     end
 
     # Match any 'dd' element.
@@ -160,8 +180,9 @@ module XPath
     # @param [String] locator
     #   Id of the 'dd' element or text from preciding 'dt' element content
     def definition_description(locator)
-      locator = locator.to_s
-      descendant(:dd)[attr(:id).equals(locator) | previous_sibling(:dt)[string.n.equals(locator)] ]
+      xpath = descendant(:dd)
+      xpath = xpath[attr(:id).equals(locator.to_s) | previous_sibling(:dt)[string.n.equals(locator.to_s)] ] unless locator.nil?
+      xpath
     end
 
   protected

--- a/spec/html_spec.rb
+++ b/spec/html_spec.rb
@@ -39,6 +39,10 @@ describe XPath::HTML do
       it("finds links by image's alt attribute")                     { get('Alt link').should == 'link-img' }
       it("does not find links by image's approximate alt attribute") { get('Alt').should be_nil }
     end
+
+    context "with nil locator" do
+      it("finds all") { all(nil).count.should == 11 }
+    end
   end
 
   describe '#button' do
@@ -134,6 +138,10 @@ describe XPath::HTML do
       it("does not find the button") { get('schmoo button').should be_nil }
     end
 
+    context "with nil locator" do
+      it("finds all") { all(nil).count.should == 50 }
+    end
+
     it("casts to string") { get(:'tag-with-tex').should == 'text-btag' }
   end
 
@@ -150,6 +158,10 @@ describe XPath::HTML do
     context "with exact match", :type => :exact do
       it("finds fieldsets by legend")            { get('Some Legend').should == 'fieldset-legend' }
       it("does not find by approximate legends") { get('Legend').should be_nil }
+    end
+
+    context "with nil locator" do
+      it("finds all") { all(nil).count.should == 7 }
     end
   end
 
@@ -213,6 +225,10 @@ describe XPath::HTML do
       it("does not find hidden fields")     { get('Input hidden with parent label').should be_nil }
     end
 
+    context "with nil locator" do
+      it("finds all") { all(nil).count.should == 68 }
+    end
+
     it("casts to string") { get(:'select-with-id').should == 'select-with-id-data' }
   end
 
@@ -223,6 +239,9 @@ describe XPath::HTML do
       it("finds inputs where label has problem chars")     { get("Label text's got an apostrophe").should == 'id-problem-text' }
     end
 
+    context "with nil locator" do
+      it("finds all") { all(nil).count.should == 47 }
+    end
   end
 
   describe '#select' do
@@ -232,6 +251,10 @@ describe XPath::HTML do
     it("finds selects by label")          { get('Select with label').should == 'select-with-label-data' }
     it("finds selects by parent label")   { get('Select with parent label').should == 'select-with-parent-label-data' }
     it("casts to string")                 { get(:'Select with parent label').should == 'select-with-parent-label-data' }
+
+    context "with nil locator" do
+      it("finds all") { all(nil).count.should == 6 }
+    end
   end
 
   describe '#checkbox' do
@@ -241,6 +264,10 @@ describe XPath::HTML do
     it("finds checkboxes by label")        { get('Input checkbox with label').should == 'input-checkbox-with-label-data' }
     it("finds checkboxes by parent label") { get('Input checkbox with parent label').should == 'input-checkbox-with-parent-label-data' }
     it("casts to string")                  { get(:'Input checkbox with parent label').should == 'input-checkbox-with-parent-label-data' }
+
+    context "with nil locator" do
+      it("finds all") { all(nil).count.should == 5 }
+    end
   end
 
   describe '#radio_button' do
@@ -250,6 +277,10 @@ describe XPath::HTML do
     it("finds radio buttons by label")        { get('Input radio with label').should == 'input-radio-with-label-data' }
     it("finds radio buttons by parent label") { get('Input radio with parent label').should == 'input-radio-with-parent-label-data' }
     it("casts to string")                     { get(:'Input radio with parent label').should == 'input-radio-with-parent-label-data' }
+
+    context "with nil locator" do
+      it("finds all") { all(nil).count.should == 5 }
+    end
   end
 
   describe '#file_field' do
@@ -259,6 +290,10 @@ describe XPath::HTML do
     it("finds file fields by label")        { get('Input file with label').should == 'input-file-with-label-data' }
     it("finds file fields by parent label") { get('Input file with parent label').should == 'input-file-with-parent-label-data' }
     it("casts to string")                   { get(:'Input file with parent label').should == 'input-file-with-parent-label-data' }
+
+    context "with nil locator" do
+      it("finds all") { all(nil).count.should == 5 }
+    end
   end
 
   describe "#optgroup" do
@@ -271,6 +306,10 @@ describe XPath::HTML do
       it("finds by label")                     { get('Group A').should == 'optgroup-a' }
       it("does not find by approximate label") { get('oup A').should be_nil }
     end
+
+    context "with nil locator" do
+      it("finds all") { all(nil).count.should == 2 }
+    end
   end
 
   describe '#option' do
@@ -282,6 +321,10 @@ describe XPath::HTML do
     context "with exact match", :type => :exact do
       it("finds by text")                     { get('Option with text').should == 'option-with-text-data' }
       it("does not find by approximate text") { get('Option with').should be_nil }
+    end
+
+    context "with nil locator" do
+      it("finds all") { all(nil).count.should == 1 }
     end
   end
 
@@ -296,6 +339,10 @@ describe XPath::HTML do
       it("finds by caption")                     { get('Table with caption').should == 'table-with-caption-data' }
       it("does not find by approximate caption") { get('Table with').should be_nil }
     end
+
+    context "with nil locator" do
+      it("finds all") { all(nil).count.should == 3 }
+    end
   end
 
   describe "#definition_description" do
@@ -304,5 +351,9 @@ describe XPath::HTML do
     it("find definition description by id")   { get('latte').should == "with-id" }
     it("find definition description by term") { get("Milk").should == "with-dt" }
     it("casts to string")                     { get(:"Milk").should == "with-dt" }
+
+    context "with nil locator" do
+      it("finds all") { all(nil).count.should == 2 }
+    end
   end
 end


### PR DESCRIPTION
Allow nil as a locator to devolve into just looking for the element types in the html methods.