### PR TITLE
support aria-label for links and buttons

### DIFF
--- a/lib/xpath/html.rb
+++ b/lib/xpath/html.rb
@@ -11,7 +11,7 @@ module XPath
     def link(locator)
       locator = locator.to_s
       link = descendant(:a)[attr(:href)]
-      link[attr(:id).equals(locator) | string.n.is(locator) | attr(:title).is(locator) | descendant(:img)[attr(:alt).is(locator)]]
+      link[attr(:id).equals(locator) | string.n.is(locator) | attr(:'aria-label').is(locator) | attr(:title).is(locator) | descendant(:img)[attr(:alt).is(locator)]]
     end
 
     # Match a `submit`, `image`, or `button` element.
@@ -21,8 +21,8 @@ module XPath
     #
     def button(locator)
       locator = locator.to_s
-      button = descendant(:input)[attr(:type).one_of('submit', 'reset', 'image', 'button')][attr(:id).equals(locator) | attr(:value).is(locator) | attr(:title).is(locator)]
-      button += descendant(:button)[attr(:id).equals(locator) | attr(:value).is(locator) | string.n.is(locator) | attr(:title).is(locator)]
+      button = descendant(:input)[attr(:type).one_of('submit', 'reset', 'image', 'button')][attr(:id).equals(locator) | attr(:value).is(locator) | attr(:'aria-label').is(locator) | attr(:title).is(locator)]
+      button += descendant(:button)[attr(:id).equals(locator) | attr(:value).is(locator) | string.n.is(locator) | attr(:'aria-label').is(locator) | attr(:title).is(locator)]
       button += descendant(:input)[attr(:type).equals('image')][attr(:alt).is(locator)]
     end
 

--- a/spec/fixtures/form.html
+++ b/spec/fixtures/form.html
@@ -11,6 +11,7 @@
   <a href="#foo" data="link-img-exact"><img src="foo.ong" alt="An image"/></a>
   <a href="http://www.example.com" data="link-href">Href-ed link</a>
   <a>Wrong Link</a>
+  <a href="#aria" aria-label="Aria link" data="link-aria"></a>
   <a href="#spacey" data="link-whitespace">    My
 
       whitespaced
@@ -25,6 +26,7 @@
   <input type="submit" value="submit-with-value" data="value-submit"/>
   <input type="submit" value="not exact value submit" data="not-exact-value-submit"/>
   <input type="submit" value="exact value submit" data="exact-value-submit"/>
+  <input type="submit" aria-label="Aria submit" data="aria-submit"/>
   <input type="submit" title="My submit title" value="submit-with-title" data="title-submit">
   <input type="submit" title="Exact submit title" value="exact title submit" data="exact-title-submit">
   <input type="submit" title="Not Exact submit title" value="exact title submit" data="not-exact-title-submit">
@@ -33,6 +35,7 @@
   <input type="reset" value="reset-with-value" data="value-reset"/>
   <input type="reset" value="not exact value reset" data="not-exact-value-reset"/>
   <input type="reset" value="exact value reset" data="exact-value-reset"/>
+  <input type="reset" aria-label="Aria reset" data="aria-reset"/>
   <input type="reset" title="My reset title" value="reset-with-title" data="title-reset">
   <input type="reset" title="Exact reset title" value="exact title reset" data="exact-title-reset">
   <input type="reset" title="Not Exact reset title" value="exact title reset" data="not-exact-title-reset">
@@ -41,6 +44,7 @@
   <input type="button" value="button-with-value" data="value-button"/>
   <input type="button" value="not exact value button" data="not-exact-value-button"/>
   <input type="button" value="exact value button" data="exact-value-button"/>
+  <input type="button" aria-label="Aria button" data="aria-button"/>
   <input type="button" title="My button title" value="button-with-title" data="title-button">
   <input type="button" title="Not Exact button title" value="not exact title button" data="not-exact-title-button">
   <input type="button" title="Exact button title" value="exact title button" data="exact-title-button">
@@ -50,6 +54,7 @@
   <input type="image" alt="imgbut-with-alt" data="alt-imgbut"/>
   <input type="image" value="not exact value imgbut" data="not-exact-value-imgbut"/>
   <input type="image" value="exact value imgbut" data="exact-value-imgbut"/>
+  <input type="image" aria-label="Aria imgbut" data="aria-imgbut"/>
   <input type="image" title="My imgbut title" value="imgbut-with-title" data="title-imgbut">
   <input type="image" title="Not Exact imgbut title" value="not exact title imgbut" data="not-exact-title-imgbut">
   <input type="image" title="Exact imgbut title" value="exact title imgbut" data="exact-title-imgbut">
@@ -62,6 +67,7 @@
   <button data="text-btag">btag-with-text</button>
   <button data="not-exact-text-btag">not exact text btag</button>
   <button data="exact-text-btag">exact text btag</button>
+  <button aria-label="Aria btag" data="aria-btag">btag-with-aria-label</button>
   <button title="My btag title" data="title-btag">btag-with-title</button>
   <button title="Not Exact btag title" data="not-exact-title-btag">not exact title btag</button>
   <button title="Exact btag title" data="exact-title-btag">exact title btag</button>

--- a/spec/html_spec.rb
+++ b/spec/html_spec.rb
@@ -24,6 +24,7 @@ describe XPath::HTML do
     it("finds links with child tags by content")           { get('An emphatic link').should == 'link-children' }
     it("finds links by the content of their child tags")   { get('emphatic').should == 'link-children' }
     it("finds links by approximate content")               { get('awesome').should == 'link-text' }
+    it("finds links by aria-label")                        { get('Aria link').should == 'link-aria' }
     it("finds links by title")                             { get('My title').should == 'link-title' }
     it("finds links by approximate title")                 { get('title').should == 'link-title' }
     it("finds links by image's alt attribute")             { get('Alt link').should == 'link-img' }
@@ -34,6 +35,7 @@ describe XPath::HTML do
     context "with exact match", :type => :exact do
       it("finds links by content")                                   { get('An awesome link').should == 'link-text' }
       it("does not find links by approximate content")               { get('awesome').should be_nil }
+      it("finds links by aria-label")                                { get('Aria link').should == 'link-aria' }
       it("finds links by title")                                     { get('My title').should == 'link-title' }
       it("does not find links by approximate title")                 { get('title').should be_nil }
       it("finds links by image's alt attribute")                     { get('Alt link').should == 'link-img' }
@@ -48,12 +50,14 @@ describe XPath::HTML do
       it("finds buttons by id")                { get('submit-with-id').should == 'id-submit' }
       it("finds buttons by value")             { get('submit-with-value').should == 'value-submit' }
       it("finds buttons by approximate value") { get('mit-with-val').should == 'value-submit' }
+      it("finds buttons by aria-label")        { get('Aria submit').should == 'aria-submit' }
       it("finds buttons by title")             { get('My submit title').should == 'title-submit' }
       it("finds buttons by approximate title") { get('submit title').should == 'title-submit' }
 
       context "with exact match", :type => :exact do
         it("finds buttons by value")                     { get('submit-with-value').should == 'value-submit' }
         it("does not find buttons by approximate value") { get('mit-with-val').should be_nil }
+        it("finds buttons by aria-label")                { get('Aria submit').should == 'aria-submit' }
         it("finds buttons by title")                     { get('My submit title').should == 'title-submit' }
         it("does not find buttons by approximate title") { get('submit title').should be_nil }
       end
@@ -63,12 +67,14 @@ describe XPath::HTML do
       it("finds buttons by id")                { get('reset-with-id').should == 'id-reset' }
       it("finds buttons by value")             { get('reset-with-value').should == 'value-reset' }
       it("finds buttons by approximate value") { get('set-with-val').should == 'value-reset' }
+      it("finds buttons by aria-label")        { get('Aria reset').should == 'aria-reset' }
       it("finds buttons by title")             { get('My reset title').should == 'title-reset' }
       it("finds buttons by approximate title") { get('reset title').should == 'title-reset' }
 
       context "with exact match", :type => :exact do
         it("finds buttons by value")                     { get('reset-with-value').should == 'value-reset' }
         it("does not find buttons by approximate value") { get('set-with-val').should be_nil }
+        it("finds buttons by aria-label")                { get('Aria reset').should == 'aria-reset' }
         it("finds buttons by title")                     { get('My reset title').should == 'title-reset' }
         it("does not find buttons by approximate title") { get('reset title').should be_nil }
       end
@@ -78,12 +84,14 @@ describe XPath::HTML do
       it("finds buttons by id")                { get('button-with-id').should == 'id-button' }
       it("finds buttons by value")             { get('button-with-value').should == 'value-button' }
       it("finds buttons by approximate value") { get('ton-with-val').should == 'value-button' }
+      it("finds buttons by aria-label")        { get('Aria button').should == 'aria-button' }
       it("finds buttons by title")             { get('My button title').should == 'title-button' }
       it("finds buttons by approximate title") { get('button title').should == 'title-button' }
 
       context "with exact match", :type => :exact do
         it("finds buttons by value")                     { get('button-with-value').should == 'value-button' }
         it("does not find buttons by approximate value") { get('ton-with-val').should be_nil }
+        it("finds buttons by aria-label")                { get('Aria button').should == 'aria-button' }
         it("finds buttons by title")                     { get('My button title').should == 'title-button' }
         it("does not find buttons by approximate title") { get('button title').should be_nil }
       end
@@ -95,6 +103,7 @@ describe XPath::HTML do
       it("finds buttons by approximate value")         { get('gbut-with-val').should == 'value-imgbut' }
       it("finds buttons by alt attribute")             { get('imgbut-with-alt').should == 'alt-imgbut' }
       it("finds buttons by approximate alt attribute") { get('mgbut-with-al').should == 'alt-imgbut' }
+      it("finds buttons by aria-label")                { get('Aria imgbut').should == 'aria-imgbut' }
       it("finds buttons by title")                     { get('My imgbut title').should == 'title-imgbut' }
       it("finds buttons by approximate title")         { get('imgbut title').should == 'title-imgbut' }
 
@@ -103,6 +112,7 @@ describe XPath::HTML do
         it("does not find buttons by approximate value")         { get('gbut-with-val').should be_nil }
         it("finds buttons by alt attribute")                     { get('imgbut-with-alt').should == 'alt-imgbut' }
         it("does not find buttons by approximate alt attribute") { get('mgbut-with-al').should be_nil }
+        it("finds buttons by aria-label")                        { get('Aria imgbut').should == 'aria-imgbut' }
         it("finds buttons by title")                             { get('My imgbut title').should == 'title-imgbut' }
         it("does not find buttons by approximate title")         { get('imgbut title').should be_nil }
       end
@@ -117,6 +127,7 @@ describe XPath::HTML do
       it("finds buttons by approximate text ")        { get('tag-with-tex').should == 'text-btag' }
       it("finds buttons with child tags by text")     { get('An emphatic button').should == 'btag-with-children' }
       it("finds buttons by text of their children")   { get('emphatic').should == 'btag-with-children' }
+      it("finds buttons by aria-label")               { get('Aria btag').should == 'aria-btag' }
       it("finds buttons by title")                    { get('My btag title').should == 'title-btag' }
       it("finds buttons by approximate title")        { get('btag title').should == 'title-btag' }
 
@@ -125,6 +136,7 @@ describe XPath::HTML do
         it("does not find buttons by approximate value") { get('tag-with-val').should be_nil }
         it("finds buttons by text")                      { get('btag-with-text').should == 'text-btag' }
         it("does not find buttons by approximate text ") { get('tag-with-tex').should be_nil }
+        it("finds buttons by aria-label")                { get('Aria btag').should == 'aria-btag' }
         it("finds buttons by title")                     { get('My btag title').should == 'title-btag' }
         it("does not find buttons by approximate title") { get('btag title').should be_nil }
       end


### PR DESCRIPTION
This does add basic `aria-label` support for links and buttons.

Eventually this has to be extended to support [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute), but that implementation is more difficult.

To take the example from the MDN website:

``` html
<div role="main" aria-labelledby="foo">
   <h1 id="foo">Wild fires spread across the San Diego Hills</h1>
   Strong winds expand fires ignited by high temperatures ...
</div>
```

Where a link selector would be:

``` rb
link("Wild fires spread across the San Diego Hills")
```

Which then find the element it is contained in, extracts the ID, and does a reverse lookup for the `aria-labelledby`. But the attribute can contain multiple ID's.

Related: https://github.com/jnicklas/capybara/issues/1528
