### PR TITLE
Update to RSpec 3

### DIFF
--- a/spec/html_spec.rb
+++ b/spec/html_spec.rb
@@ -11,8 +11,12 @@ describe XPath::HTML do
   end
 
   def all(*args)
-    type = example.metadata[:type]
+    type = @example.metadata[:type]
     doc.xpath(XPath::HTML.send(subject, *args).to_xpath(type)).map { |node| node[:data] }
+  end
+
+  before(:each) do |example|
+    @example = example
   end
 
   describe '#link' do

--- a/xpath.gemspec
+++ b/xpath.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("nokogiri", ["~> 1.3"])
 
-  s.add_development_dependency("rspec", ["~> 2.0"])
+  s.add_development_dependency("rspec", ["~> 3.0"])
   s.add_development_dependency("yard", [">= 0.5.8"])
   s.add_development_dependency("rake")
 


### PR DESCRIPTION
Hi, I modified the code to run the unit test on RSpec 3 from RSpec 2, because I wanted to use RSpec 3.

The related changing point from Rspec 2 to 3 for "xpath" is just one point.
That is "example" is changed from the method to block argument.

See for detail.

> https://github.com/rspec/rspec-core/blob/master/Changelog.md
> Block-based DSL methods that run in the context of an example (it, before(:each), after(:each), let and subject) now yield the example as a block argument. (David Chelimsky)

> https://github.com/rspec/rspec-core/pull/666

I prepared 2 ways to fix this.
One is this pull-request. Simple way to fix it.

However perhaps if you like below way with many modified lines, you can use it too.
https://github.com/junaruga/xpath/commit/af1671a4566256feadb7002a960ff17dce5eb8c7

Thanks.